### PR TITLE
Fix RPM building for layercake

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/gorilla/mux v1.8.0
 	github.com/kraken-hpc/go-fork v0.1.1
 	github.com/kraken-hpc/imageapi v0.1.4
-	github.com/kraken-hpc/kraken v0.0.0-20210323174739-68c1e3706fb2
+	github.com/kraken-hpc/kraken v0.0.0-20210324190123-ba28824525d3
 	github.com/kraken-hpc/powerapi v0.1.1
 	github.com/mdlayher/raw v0.0.0-20191009151244-50f2db8cc065
 	github.com/pin/tftp v2.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -298,6 +298,8 @@ github.com/kraken-hpc/imageapi v0.1.4 h1:+lzhHR1oy2rYoXgwJnneQ21UcgWJr5wBfs5GA+E
 github.com/kraken-hpc/imageapi v0.1.4/go.mod h1:kDKd8QJ6fp2Hf2pfbCEqFeSDF0MNplcu1xuUBOHYkY4=
 github.com/kraken-hpc/kraken v0.0.0-20210323174739-68c1e3706fb2 h1:e0zB3Gpl09jB3E1KMnyEiXqEiZy462db3nAbqLgLiIU=
 github.com/kraken-hpc/kraken v0.0.0-20210323174739-68c1e3706fb2/go.mod h1:huFcZJwyKlOscTaVIPanknLJJNxsNvRiJOqcgrBcvJo=
+github.com/kraken-hpc/kraken v0.0.0-20210324190123-ba28824525d3 h1:uZaTUwwC8vAq344BgnhsrK+8hMXo+wOu9laUG9ZfcdM=
+github.com/kraken-hpc/kraken v0.0.0-20210324190123-ba28824525d3/go.mod h1:huFcZJwyKlOscTaVIPanknLJJNxsNvRiJOqcgrBcvJo=
 github.com/kraken-hpc/powerapi v0.1.1 h1:wk6xZ4QxA6gilfr2uVoHzaatRHy812r9JPwehejvvdc=
 github.com/kraken-hpc/powerapi v0.1.1/go.mod h1:/9tKJzNkAHXVZmtRRWrhQzVA6HenzcubYNFC4k58wqQ=
 github.com/kraken-hpc/uinit v0.1.1/go.mod h1:S09qeh87rhAU14nENTRIggeF/tC6n+QJAYvW11UP4HI=

--- a/utils/rpm/README.md
+++ b/utils/rpm/README.md
@@ -1,21 +1,28 @@
-# Kraken RPM building
+# Kraken/Layercake RPM building
 
 This directory contains the necessary files to build RPMs.
 
-The spec file, `kraken.spec`, allows for building cross-architecture RPMs with the kraken build config of your choosing.
+The spec file, `kraken-layercake.spec`, allows for building cross-architecture RPMs.
 
-Here's an example.  Suppose you have the kraken source in `$HOME/kraken` and you want to build an `arm64` version of the `vbox` config.
+Here's an example.  Suppose you have the layercake source in `$HOME/kraken-kraken` and you want to build an `arm64` binary.
 
-```console
-$ cd $HOME/kraken
-$ git archive -o ../kraken-1.0.tar.gz --prefix=kraken-1.0/ HEAD
-$ rpmbuild --target aarch64-generic-linux -D 'KrakenConfig $PWD/config/vbox.yaml' -D 'dist vbox' -ta ../kraken-1.0.tar.gz
+```bash
+$ cd $HOME/kraken-layercake
+$ git archive -o ../kraken-layercake-0.1.0.tar.gz --prefix=kraken-layercake-0.1.0/ HEAD
+$ rpmbuild --target aarch64-generic-linux -ta ../kraken-layercake-0.1.0.tar.gz
 ```
 
-This will build an aarch64 RPM that can be found under `$HOME/rpmbuild/RPMS/aarch64` named `kraken-1.0-0vbox.aarch64.rpm`.
+This will build an aarch64 RPM that can be found under `$HOME/rpmbuild/RPMS/aarch64` named `kraken-layercake-0.1.0-0.aarch64.rpm`.
 
 If `--target` is not specified `rpmbuild` will build a native architecture build.
 
-If you don't specify `KrakenConfig` it will default to `kraken.yaml` (in the `rpmbuild/SOURCES` directory).  If that file does not exist, the build will fail.  The `KrakenConfig` should generally be an absolute path, or located in `rpmbuild/SOURCES`.
+There are three optional packages that can be built with the `--with` option:
+- *vbox* - This builds a version of layercake that has the vbox extension/module.  This is mostly used for experimentation/testing/examples.
+- *vboxapi* - This will build the vboxapi service which provides a restful wrapper around vboxmanage.  This is used by the vbox build.
+- *initramfs* - This will build a base initramfs.
 
-It is recommended that you specifiy `dist` to make it clear which build config kraken was based on.
+To build all available packages, e.g.:
+
+```bash
+$ rpmbuild --with vbox --with vboxapi --with initramfs -ta ../kraken-layercake-0.1.0.tar.gz
+```

--- a/utils/rpm/kraken-layercake-vbox.service
+++ b/utils/rpm/kraken-layercake-vbox.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Kraken/Layercake cluster management (vbox)
+After=network.target network-online.target
+Requires=network.target
+
+[Service]
+Type=notify
+WorkingDirectory=%{?KrakenWorkingDirectory}%{?!KrakenWorkingDirectory:/}
+ExecStart=%{_sbindir}/kraken-layercake-vbox -config %{_sysconfdir}/kraken/layercake/config.yaml -noprefix -sdnotify
+
+[Install]
+WantedBy=multi-user.target

--- a/utils/rpm/kraken-layercake.service
+++ b/utils/rpm/kraken-layercake.service
@@ -1,12 +1,12 @@
 [Unit]
-Description=Kraken distributed state engine
+Description=Kraken/Layercake cluster management
 After=network.target network-online.target
 Requires=network.target
 
 [Service]
 Type=notify
 WorkingDirectory=%{?KrakenWorkingDirectory}%{?!KrakenWorkingDirectory:/}
-ExecStart=%{_sbindir}/kraken -config %{_sysconfdir}/kraken/config.yaml -noprefix -sdnotify
+ExecStart=%{_sbindir}/kraken-layercake -config %{_sysconfdir}/kraken/layercake/config.yaml -noprefix -sdnotify
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Post split, the RPM build process was broken.  This PR fixes RPM building.  The one exception is `--with initramfs` which needs fixes to `buildlayer0(_uroot).sh` which are not yet in place.