### PR TITLE
RPM & build-layer0-base fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,11 +27,12 @@ jobs:
           command: |
             cd cmd/kraken-layercake-vbox
             go build .
-      - run:
-          name: Build layer0-base
-          command: |
-            cd utils/layer0
-            bash build-layer0-base.sh amd64
+# this test currently does not work because the container doesn't have cpio
+#      - run:
+#          name: Build layer0-base
+#          command: |
+#            cd utils/layer0
+#            bash build-layer0-base.sh amd64
       - store_test_results:
           path: /tmp/test-reports
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,12 +27,11 @@ jobs:
           command: |
             cd cmd/kraken-layercake-vbox
             go build .
-# this script doesn't currently work in the circleci container (failes to mktemp with "invalid option -m")
-#      - run:
-#          name: Build layer0-base
-#          command: |
-#            cd utils/layer0
-#            bash build-layer0-base.sh amd64
+      - run:
+          name: Build layer0-base
+          command: |
+            cd utils/layer0
+            bash build-layer0-base.sh amd64
       - store_test_results:
           path: /tmp/test-reports
   test:

--- a/utils/layer0/build-layer0-base.sh
+++ b/utils/layer0/build-layer0-base.sh
@@ -90,7 +90,7 @@ UROOT="github.com/u-root/u-root"
 
 # make a temporary directory for our base
 if [ -z ${TMPDIR+x} ]; then
-    TMPDIR="$PWD/$(mktemp -tmpdir -d layer0-base.XXXXXXXXXXXX)"
+    TMPDIR="$(mktemp --tmpdir -d layer0-base.XXXXXXXXXXXX)"
 else 
     if [ ! -d "$TMPDIR" ]; then
         echo "Creating $TMPDIR"

--- a/utils/layer0/build-layer0-base.sh
+++ b/utils/layer0/build-layer0-base.sh
@@ -11,7 +11,7 @@
 ###
 
 usage() {
-        echo "Usage: $0 [-kh] [-o <out_file>] [-b <base_dir>] [ -t <tmp_dir> ] <arch> [<additional_go_cmd> ...]"
+        echo "Usage: $0 [-xkh] [-o <out_file>] [-b <base_dir>] [ -t <tmp_dir> ] <arch> [<additional_go_cmd> ...]"
         echo "  <arch> should be the GOARCH we want to build (e.g. arm64, amd64...)"
         echo "  <out_file> is the file the image should be written to.  (default: layer0-00-base.<date>.<arch>.cpio.xz)"
         echo "  <base_dir> is an optional base directory containing file/directory structure (default: none)"
@@ -19,6 +19,7 @@ usage() {
         echo "  <tmp_dir> is a temporary directory to use.  This can be used to resume a previous build"
         echo "            IMPORTANT: tmp_dir cannot sit inside of a moduled go directory!"
         echo "  <additional_go_cmd> is a go cmd path spec that should be built into the busybox"
+        echo "  [-x] don't include the default list of extra commands (u-root commands only)"
         echo "  [-k] keep temporary directory (do not delete)"
         echo "  [-h] display this usage information and exit"
 }
@@ -35,6 +36,7 @@ if ! opts=$(getopt o:b:t:kh "$@"); then
 fi
 
 DELETE_TMPDIR=1
+NO_EXTRAS=0
 # shellcheck disable=SC2086
 set -- $opts
 for i; do
@@ -58,6 +60,9 @@ for i; do
         -k) echo "Will not delete temporary directory at the end"
             DELETE_TMPDIR=0
             shift;;
+        -x) echo "Will not include default extra commands"
+            NO_EXTRAS=1
+            shift;;
         --)
             shift; break;;
     esac
@@ -73,12 +78,14 @@ shift
 
 # Commands to build into u-root busybox
 EXTRA_COMMANDS=()
-EXTRA_COMMANDS+=( github.com/kraken-hpc/kraken-layercake/cmd/kraken-layercake )
-EXTRA_COMMANDS+=( github.com/kraken-hpc/uinit/cmds/uinit )
-EXTRA_COMMANDS+=( github.com/kraken-hpc/imageapi/cmd/imageapi-server )
-EXTRA_COMMANDS+=( github.com/jlowellwofford/entropy/cmd/entropy )
-EXTRA_COMMANDS+=( github.com/bensallen/modscan/cmd/modscan )
-EXTRA_COMMANDS+=( github.com/bensallen/rbd/cmd/rbd )
+if [ $NO_EXTRAS -eq 0 ]; then
+    EXTRA_COMMANDS+=( github.com/kraken-hpc/kraken-layercake/cmd/kraken-layercake )
+    EXTRA_COMMANDS+=( github.com/kraken-hpc/uinit/cmds/uinit )
+    EXTRA_COMMANDS+=( github.com/kraken-hpc/imageapi/cmd/imageapi-server )
+    EXTRA_COMMANDS+=( github.com/jlowellwofford/entropy/cmd/entropy )
+    EXTRA_COMMANDS+=( github.com/bensallen/modscan/cmd/modscan )
+    EXTRA_COMMANDS+=( github.com/bensallen/rbd/cmd/rbd )
+fi
 
 while (( "$#" )); do 
     echo "Adding command $1"
@@ -121,17 +128,16 @@ done
 IFS=$'\n' EXTRA_MODS=($( sort -u <<<"${EXTRA_MODS[*]}")); unset IF
 
 # fixup mod deps
-for m in "${ETRA_MODS[@]}"; do
-    (
-        cd "$GOPATH/src/$m" || fatal "couldn't cd to $GOPATH/src/$m"
-        if [ -d "vendor" ]; then
-            echo "Removing vendor folder $PWD/vendor"
-            rm -rf "$PWD/vendor"
-        fi
-        for mm in "${EXTRA_MODS[@]}"; do 
-            go mod edit -replace="$mm=$GOPATH/src/$mm"
-        done
-    )
+for m in "${EXTRA_MODS[@]}"; do
+    echo "Processing module $m"
+    cd "$GOPATH/src/$m" || fatal "couldn't cd to $GOPATH/src/$m"
+    if [ -d "vendor" ]; then
+        echo "Removing vendor folder $PWD/vendor"
+        rm -rf "$PWD/vendor"
+    fi
+    for mm in "${EXTRA_MODS[@]}"; do 
+        go mod edit -replace="$mm=$GOPATH/src/$mm"
+    done
 done
 
 # Check that gobusybox is installed, clone it if not
@@ -156,7 +162,7 @@ done
 # Create BusyBox binary (outside of u-root)
 echo "Creating BusyBox binary..."
 mkdir -p "$TMPDIR"/base/bbin
-printf "Command list: %s" "${BB_COMMANDS[@]}"
+printf "Command list: %s\n" "${BB_COMMANDS[@]}"
 # shellcheck disable=SC2068
 "$GOPATH"/bin/makebb -o "$TMPDIR"/base/bbin/bb ${BB_COMMANDS[@]} || fatal "makebb: failed to create BusyBox binary"
 

--- a/utils/layer0/build-layer0-base.sh
+++ b/utils/layer0/build-layer0-base.sh
@@ -116,16 +116,20 @@ for c in "${EXTRA_COMMANDS[@]}"; do
     EXTRA_MODS+=( "$MOD" )
 done
 
+# make our extra mods list unique
+# shellcheck disable=SC2207
+IFS=$'\n' EXTRA_MODS=($( sort -u <<<"${EXTRA_MODS[*]}")); unset IF
+
 # fixup mod deps
-for c in "${EXTRA_COMMANDS[@]}"; do
+for m in "${ETRA_MODS[@]}"; do
     (
-        cd "$GOPATH/src/$c" || fatal "couldn't cd to $GOPATH/src/$c"
+        cd "$GOPATH/src/$m" || fatal "couldn't cd to $GOPATH/src/$m"
         if [ -d "vendor" ]; then
             echo "Removing vendor folder $PWD/vendor"
             rm -rf "$PWD/vendor"
         fi
-        for m in "${EXTRA_MODS[@]}"; do 
-            go mod edit -replace="$m=$GOPATH/src/$m"
+        for mm in "${EXTRA_MODS[@]}"; do 
+            go mod edit -replace="$mm=$GOPATH/src/$mm"
         done
     )
 done

--- a/utils/rpm/README.md
+++ b/utils/rpm/README.md
@@ -17,12 +17,22 @@ This will build an aarch64 RPM that can be found under `$HOME/rpmbuild/RPMS/aarc
 If `--target` is not specified `rpmbuild` will build a native architecture build.
 
 There are three optional packages that can be built with the `--with` option:
-- *vbox* - This builds a version of layercake that has the vbox extension/module.  This is mostly used for experimentation/testing/examples.
-- *vboxapi* - This will build the vboxapi service which provides a restful wrapper around vboxmanage.  This is used by the vbox build.
 - *initramfs* - This will build a base initramfs.
+- *vbox* - This builds a version of layercake that has the vbox extension/module.  This is mostly used for experimentation/testing/examples.
+  This will also build the `vboxapi` package and, if `initramfs` is also specified, the `initramfs-vbox` pacakge.
 
 To build all available packages, e.g.:
 
 ```bash
-$ rpmbuild --with vbox --with vboxapi --with initramfs -ta ../kraken-layercake-0.1.0.tar.gz
+$ rpmbuild --with vbox --with initramfs -ta ../kraken-layercake-0.1.0.tar.gz
+```
+
+This would would create the following RPMS:
+
+```bash
+./x86_64/kraken-layercake-0.1.0-rc1.fc33.x86_64.rpm
+./x86_64/kraken-layercake-vbox-0.1.0-rc1.fc33.x86_64.rpm
+./x86_64/kraken-layercake-vboxapi-0.1.0-rc1.fc33.x86_64.rpm
+./noarch/kraken-layercake-initramfs-vbox-amd64-0.1.0-rc1.fc33.noarch.rpm
+./noarch/kraken-layercake-initramfs-amd64-0.1.0-rc1.fc33.noarch.rpm
 ```

--- a/utils/rpm/kraken-layercake.spec
+++ b/utils/rpm/kraken-layercake.spec
@@ -108,7 +108,7 @@ bash utils/layer0/build-layer0-base.sh -k -t /tmp/layer0-base -o layer0-base-%{G
 bash utils/layer0/build-layer0-base.sh -k -t /tmp/layer0-base -o layer0-vbox-base-%{GoBuildArch}.xz %{GoBuildArch} github.com/kraken-hpc/kraken-layercake/cmd/kraken-layercake-vbox
 
 %endif
-#rm -rf /tmp/layer0-base
+rm -rf /tmp/layer0-base
 %endif
 
 %install

--- a/utils/rpm/kraken-layercake.spec
+++ b/utils/rpm/kraken-layercake.spec
@@ -100,14 +100,15 @@ GOARCH=%{GoBuildArch} go build ./cmd/kraken-layercake
 
 %if %{with initramfs}
 # build initramfs
-bash utils/layer0/build-layer0-base.sh -o layer0-base-%{GoBuildArch}.xz %{GoBuildArch}
+bash utils/layer0/build-layer0-base.sh -k -t /tmp/layer0-base -o layer0-base-%{GoBuildArch}.xz %{GoBuildArch}
 
 %if %{with vbox}
 # build an initramfs that has kraken-layercake-vbox in it
 # note: still has non-vbox version too
-bash utils/layer0/build-layer0-base.sh -o layer0-vbox-base-%{GoBuildArch}.xz %{GoBuildArch} github.com/kraken-hpc/kraken-layercake/cmd/kraken-layercake-vbox
+bash utils/layer0/build-layer0-base.sh -k -t /tmp/layer0-base -o layer0-vbox-base-%{GoBuildArch}.xz %{GoBuildArch} github.com/kraken-hpc/kraken-layercake/cmd/kraken-layercake-vbox
 
 %endif
+#rm -rf /tmp/layer0-base
 %endif
 
 %install
@@ -130,9 +131,9 @@ install -D -m 0644 vboxapi.environment %{buildroot}%{_sysconfdir}/sysconfig/vbox
 %endif
 %if %{with initramfs}
 # initramfs
-install -D -m 0644 initramfs-base-%{GoBuildArch}.xz %{buildroot}/tftp/layer0-base-%{GoBuildArch}.xz
+install -D -m 0644 layer0-base-%{GoBuildArch}.xz %{buildroot}/tftp/layer0-base-%{GoBuildArch}.xz
 %if %{with vbox}
-install -D -m 0644 initramfs-vbox-base-%{GoBuildArch}.xz %{buildroot}/tftp/layer0-vbox-base-%{GoBuildArch}.xz
+install -D -m 0644 layer0-vbox-base-%{GoBuildArch}.xz %{buildroot}/tftp/layer0-vbox-base-%{GoBuildArch}.xz
 %endif
 %endif
 
@@ -162,11 +163,11 @@ install -D -m 0644 initramfs-vbox-base-%{GoBuildArch}.xz %{buildroot}/tftp/layer
 %if %{with initramfs}
 %files initramfs-%{GoBuildArch}
 %license LICENSE
-/tftp/layer0-base-%{GoBuildArch}.gz
+/tftp/layer0-base-%{GoBuildArch}.xz
 %if %{with vbox}
 %files initramfs-vbox-%{GoBuildArch}
 %license LICENSE
-/tftp/layer0-vbox-base-%{GoBuildArch}.gz
+/tftp/layer0-vbox-base-%{GoBuildArch}.xz
 %endif
 %endif
 

--- a/utils/rpm/kraken-layercake.spec
+++ b/utils/rpm/kraken-layercake.spec
@@ -10,7 +10,6 @@ BuildRequires:  go, golang >= 1.15, golang-bin, golang-src %define  debug_packag
 
 %bcond_with initramfs
 %bcond_with vbox
-%bcond_with vboxapi
 
 %if "%{_arch}" == "x86_64"
 %define GoBuildArch amd64
@@ -37,6 +36,16 @@ Group: Applications/System
 Summary: A base initramfs for use with Kraken PXE configurations (%{GoBuildArch}).
 %description initramfs-%{GoBuildArch}
 This package installs a pre-built base initramfs (arch: %{GoBuildArch}) for use with a Kraken PXE setup.  This initramfs should be layered with at least two other pieces: 1. a set of needed system modules; 2. a set of configuration files (e.g. uinit.script).
+
+%if %{with vbox}
+# Build the initramfs-vbox
+%package initramfs-vbox-%{GoBuildArch}
+BuildArch: noarch
+Group: Applications/System
+Summary: A base initramfs for use with Kraken PXE configurations (%{GoBuildArch}).
+%description initramfs-vbox-%{GoBuildArch}
+This package installs a pre-built base initramfs (arch: %{GoBuildArch}) for use with a Kraken PXE setup.  This initramfs should be layered with at least two other pieces: 1. a set of needed system modules; 2. a set of configuration files (e.g. uinit.script).
+%endif
 %endif
 
 %if %{with vbox}
@@ -47,7 +56,7 @@ Summary: Provides a vbox-enabled Kraken/Layercake.
 Provides a vbox-enabled kraken-layercake. This version of Layercake is primarily intended for demonstrations and examples using VirtualBox.
 %endif
 
-%if %{with vboxapi}
+%if %{with vbox}
 %package vboxapi
 Group: Applications/System
 Summary: Provides the vboxapi service which wraps Oracle VirtualBox with a simple restful API service for power control of VMs.
@@ -81,7 +90,7 @@ GOARCH=%{GoBuildArch} go build ./cmd/kraken-layercake
 )
 %endif
 
-%if %{with vboxapi}
+%if %{with vbox}
 # build vboxapi
 (
   cd utils/vboxapi
@@ -91,13 +100,14 @@ GOARCH=%{GoBuildArch} go build ./cmd/kraken-layercake
 
 %if %{with initramfs}
 # build initramfs
-export GOPATH=%{_builddir}/go
-mkdir -p $GOPATH/src/github.com/kraken-hpc
-ln -s $PWD $GOPATH/src/github.com/kraken-hpc/kraken
-bash utils/layer0/buildlayer0_uroot.sh -o initramfs-base-%{GoBuildArch}.gz %{GoBuildArch}
+bash utils/layer0/build-layer0-base.sh -o initramfs-base-%{GoBuildArch}.xz %{GoBuildArch}
 
-chmod -R u+w $GOPATH
-rm -rf $GOPATH
+%if %{with vbox}
+# build an initramfs that has kraken-layercake-vbox in it
+# note: still has non-vbox version too
+bash utils/layer0/build-layer0-base.sh -o initramfs-vbox-base-%{GoBuildArch}.xz %{GoBuildArch} github.com/kraken-hpc/kraken-layercake/cmd/kraken-layercake-vbox
+
+%endif
 %endif
 
 %install
@@ -113,8 +123,6 @@ install -D -m 0755 kraken-layercake-vbox %{buildroot}%{_sbindir}/kraken-layercak
 install -D -m 0644 kraken-layercake-vbox.service %{buildroot}%{_unitdir}/kraken-layercake-vbox.service
 install -D -m 0644 utils/rpm/state.json %{buildroot}%{_sysconfdir}/kraken/layercake-vbox/state.json
 install -D -m 0644 layercake-vbox-config.yaml %{buildroot}%{_sysconfdir}/kraken/layercake-vbox/config.yaml
-%endif
-%if %{with vboxapi}
 # vboxapi
 install -D -m 0755 utils/vboxapi/vboxapi %{buildroot}%{_sbindir}/vboxapi
 install -D -m 0644 vboxapi.service %{buildroot}%{_unitdir}/vboxapi.service
@@ -122,7 +130,10 @@ install -D -m 0644 vboxapi.environment %{buildroot}%{_sysconfdir}/sysconfig/vbox
 %endif
 %if %{with initramfs}
 # initramfs
-install -D -m 0644 initramfs-base-%{GoBuildArch}.gz %{buildroot}/tftp/initramfs-base-%{GoBuildArch}.gz
+install -D -m 0644 initramfs-base-%{GoBuildArch}.xz %{buildroot}/tftp/initramfs-base-%{GoBuildArch}.xz
+%if %{with vbox}
+install -D -m 0644 initramfs-vbox-base-%{GoBuildArch}.xz %{buildroot}/tftp/initramfs-vbox-base-%{GoBuildArch}.xz
+%endif
 %endif
 
 %files
@@ -140,9 +151,7 @@ install -D -m 0644 initramfs-base-%{GoBuildArch}.gz %{buildroot}/tftp/initramfs-
 %config(noreplace) %{_sysconfdir}/kraken/layercake-vbox/state.json
 %config(noreplace) %{_sysconfdir}/kraken/layercake-vbox/config.yaml
 %{_unitdir}/kraken-layercake-vbox.service
-%endif
 
-%if %{with vboxapi}
 %files vboxapi
 %license LICENSE
 %{_sbindir}/vboxapi
@@ -154,10 +163,20 @@ install -D -m 0644 initramfs-base-%{GoBuildArch}.gz %{buildroot}/tftp/initramfs-
 %files initramfs-%{GoBuildArch}
 %license LICENSE
 /tftp/initramfs-base-%{GoBuildArch}.gz
+%if %{with vbox}
+%files initramfs-vbox-%{GoBuildArch}
+%license LICENSE
+/tftp/initramfs-vbox-base-%{GoBuildArch}.gz
+%endif
 %endif
 
 %changelog
-* Wed Mar 24 2021 J. Lowell Wofford <lowelL@lanl.gov> 0.1.0-rc0
+* Fri Mar 26 2021 J. Lowell Wofford <lowell@lanl.gov> 0.1.0-rc1
+- Combine vbox and vboxapi options into one vbox option for all vbox-related packages
+- Fix initramfs building
+- Build an initramfs-vbox-base if vbox is specified
+
+* Wed Mar 24 2021 J. Lowell Wofford <lowell@lanl.gov> 0.1.0-rc0
 - Migrate to kraken-layercake from kraken
 - Build/install kraken-layercake-vbox if vbox is specified
 - Remove the depricated powermanapi

--- a/utils/rpm/kraken-layercake.spec
+++ b/utils/rpm/kraken-layercake.spec
@@ -100,12 +100,12 @@ GOARCH=%{GoBuildArch} go build ./cmd/kraken-layercake
 
 %if %{with initramfs}
 # build initramfs
-bash utils/layer0/build-layer0-base.sh -o initramfs-base-%{GoBuildArch}.xz %{GoBuildArch}
+bash utils/layer0/build-layer0-base.sh -o layer0-base-%{GoBuildArch}.xz %{GoBuildArch}
 
 %if %{with vbox}
 # build an initramfs that has kraken-layercake-vbox in it
 # note: still has non-vbox version too
-bash utils/layer0/build-layer0-base.sh -o initramfs-vbox-base-%{GoBuildArch}.xz %{GoBuildArch} github.com/kraken-hpc/kraken-layercake/cmd/kraken-layercake-vbox
+bash utils/layer0/build-layer0-base.sh -o layer0-vbox-base-%{GoBuildArch}.xz %{GoBuildArch} github.com/kraken-hpc/kraken-layercake/cmd/kraken-layercake-vbox
 
 %endif
 %endif
@@ -130,9 +130,9 @@ install -D -m 0644 vboxapi.environment %{buildroot}%{_sysconfdir}/sysconfig/vbox
 %endif
 %if %{with initramfs}
 # initramfs
-install -D -m 0644 initramfs-base-%{GoBuildArch}.xz %{buildroot}/tftp/initramfs-base-%{GoBuildArch}.xz
+install -D -m 0644 initramfs-base-%{GoBuildArch}.xz %{buildroot}/tftp/layer0-base-%{GoBuildArch}.xz
 %if %{with vbox}
-install -D -m 0644 initramfs-vbox-base-%{GoBuildArch}.xz %{buildroot}/tftp/initramfs-vbox-base-%{GoBuildArch}.xz
+install -D -m 0644 initramfs-vbox-base-%{GoBuildArch}.xz %{buildroot}/tftp/layer0-vbox-base-%{GoBuildArch}.xz
 %endif
 %endif
 
@@ -162,11 +162,11 @@ install -D -m 0644 initramfs-vbox-base-%{GoBuildArch}.xz %{buildroot}/tftp/initr
 %if %{with initramfs}
 %files initramfs-%{GoBuildArch}
 %license LICENSE
-/tftp/initramfs-base-%{GoBuildArch}.gz
+/tftp/layer0-base-%{GoBuildArch}.gz
 %if %{with vbox}
 %files initramfs-vbox-%{GoBuildArch}
 %license LICENSE
-/tftp/initramfs-vbox-base-%{GoBuildArch}.gz
+/tftp/layer0-vbox-base-%{GoBuildArch}.gz
 %endif
 %endif
 


### PR DESCRIPTION
1) RPM building will now successfully build initramfs RPMs
2) The RPM `vbox` and `vboxapi` options have been merged into just `vbox`
3) A number of bugs in `build-layer0-base.sh` were ironed out
4) Added the `-x` option to `build-layer0-base.sh` to exclude default extra_commands