### PR TITLE
Podman example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,4 @@ state.json
 /kraken-build
 **/*.swp
 cmd/kraken-layercake/kraken-layercake
-cmd/kraken-layercake-vbox/kraken-layercake-vbox
+cmd/kraken-layercake-virt/kraken-layercake-virt

--- a/examples/vbox-layer0/Vagrantfile
+++ b/examples/vbox-layer0/Vagrantfile
@@ -45,5 +45,7 @@ Vagrant.configure("2") do |config|
     ansible.install = false
     ansible.verbose = false
     ansible.playbook = "ansible/kraken.yml"
+    ansible.galaxy_role_file = "ansible/requirements.yml"
+    ansible.galaxy_command = "ansible-galaxy collection install --requirements-file %{role_file}"
   end
 end

--- a/examples/vbox-layer0/ansible/kraken.yml
+++ b/examples/vbox-layer0/ansible/kraken.yml
@@ -4,12 +4,15 @@
     kr_repo: https://github.com/kraken-hpc/kraken-layercake.git
     kr_repo_version: "main"
     kr_build_args: "-v -force"
+    # build with vbox?
+    kr_with_vbox: true
+    # build rpm instead of direct compilation?
+    kr_rpm: false
   roles:
     - common
-    - kraken_build
     - kraken_tftpboot
-    - kraken_build_layer0
     - kraken_state
+    - kraken_podman
     - kraken_systemd
     - kraken_dashboard
 #    - extras

--- a/examples/vbox-layer0/ansible/kraken.yml
+++ b/examples/vbox-layer0/ansible/kraken.yml
@@ -10,8 +10,10 @@
     kr_rpm: false
   roles:
     - common
+    - kraken_git
     - kraken_tftpboot
     - kraken_state
+    - kraken_build_layer0
     - kraken_podman
     - kraken_systemd
     - kraken_dashboard

--- a/examples/vbox-layer0/ansible/requirements.yml
+++ b/examples/vbox-layer0/ansible/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - containers.podman

--- a/examples/vbox-layer0/release-the-kraken.sh
+++ b/examples/vbox-layer0/release-the-kraken.sh
@@ -121,7 +121,7 @@ nohup go run "${VBOXAPI}" -v -ip "${VBOXNET_IP}" -vbm "${VB}" > log/vboxapi.log 
 
 echo "Creating and provisioning the kraken parent (this may take a while)..."
 echo RUN: "${VG}" up kraken
-"${VG}" up kraken 2>&1 | tee -a log/vagrant-up-kraken.log
+"${VG}" up --provision kraken 2>&1 | tee -a log/vagrant-up-kraken.log
 
 if command -v open > /dev/null; then
     echo "Launching dashboard viewer to: http://${KRAKEN_IP}/"

--- a/examples/vbox-layer0/release-the-kraken.sh
+++ b/examples/vbox-layer0/release-the-kraken.sh
@@ -120,8 +120,13 @@ echo RUN: nohup go run "${VBOXAPI}" -v -ip "${VBOXNET_IP}"
 nohup go run "${VBOXAPI}" -v -ip "${VBOXNET_IP}" -vbm "${VB}" > log/vboxapi.log &
 
 echo "Creating and provisioning the kraken parent (this may take a while)..."
-echo RUN: "${VG}" up kraken
-"${VG}" up --provision kraken 2>&1 | tee -a log/vagrant-up-kraken.log
+if "$VB" list vms | grep -q kraken; then
+    echo RUN: "${VG}" reload kraken
+    "${VG}" reload --provision kraken 2>&1 | tee -a log/vagrant-up-kraken.log
+else 
+    echo RUN: "${VG}" up kraken
+    "${VG}" up --provision kraken 2>&1 | tee -a log/vagrant-up-kraken.log
+fi
 
 if command -v open > /dev/null; then
     echo "Launching dashboard viewer to: http://${KRAKEN_IP}/"

--- a/examples/vbox-layer0/support/base/uinit.script
+++ b/examples/vbox-layer0/support/base/uinit.script
@@ -64,10 +64,10 @@
   args:
     cmd: /bbin/ip link set {{.iface}} up
 
-- name: Start kraken-layercake-vbox
+- name: Start kraken-layercake-virt
   module: command
   args:
-    cmd: /bbin/kraken-layercake-vbox -ip {{.ip}} -parent {{.parent}} -id {{.id}} -log {{.loglevel}}
+    cmd: /bbin/kraken-layercake-virt -ip {{.ip}} -parent {{.parent}} -id {{.id}} -log {{.loglevel}}
     background: true
 
 - name: Start sshd


### PR DESCRIPTION
This PR changes the vbox example to run Kraken in a podman container in the VM instead of directly in the VM. By doing this, we avoid the need to build Kraken because it's already built in the docker image. 

I mostly focused on getting the vbox example working and am sure I broke the rpm building stuff in the process.

kraken-layercake-ansible PR: https://github.com/kraken-hpc/kraken-layercake-ansible/pull/5