### PR TITLE
Remove kraken-layercake build-layer0 script

### DIFF
--- a/utils/docker/Dockerfile
+++ b/utils/docker/Dockerfile
@@ -52,7 +52,7 @@ RUN mkdir -p /tftp/amd64/powerapi/pxelinux.cfg \
 
 # build layer0-base
 # note: we have to use -t because `mktemp` is not gnu compliant
-RUN bash utils/layer0/build-layer0-base.sh -g -o /tftp/amd64/powerapi/layer0-base.gz -t /tmp/layer0-base "$GOARCH"
+RUN bash utils/layer0/build-layer0-base.sh -g -o /tftp/amd64/powerapi/layer0-base.gz -t /tmp/layer0-base "$GOARCH" github.com/kraken-hpc/kraken-layercake/cmd/kraken-layercake
 
 # build layer0-config (stubs)
 RUN cp -av utils/docker/config /tftp/layer0/config \

--- a/utils/layer0/build-layer0-base.sh
+++ b/utils/layer0/build-layer0-base.sh
@@ -88,7 +88,6 @@ shift
 # Commands to build into u-root busybox
 EXTRA_COMMANDS=()
 if [ $NO_EXTRAS -eq 0 ]; then
-    EXTRA_COMMANDS+=( github.com/kraken-hpc/kraken-layercake/cmd/kraken-layercake )
     EXTRA_COMMANDS+=( github.com/kraken-hpc/uinit/cmds/uinit )
     EXTRA_COMMANDS+=( github.com/kraken-hpc/imageapi/cmd/imageapi-server )
     EXTRA_COMMANDS+=( github.com/jlowellwofford/entropy/cmd/entropy )


### PR DESCRIPTION
This PR removes `github.com/kraken-hpc/kraken-layercake/cmd/kraken-layercake` from the build-layer0 script because it was conflicting with `github.com/kraken-hpc/kraken-layercake/cmd/kraken-layercake-virt`

You now must include `github.com/kraken-hpc/kraken-layercake/cmd/kraken-layercake` as an extra command in the build-layer0 script if you want the non-virt layer0