### PR TITLE
Example tweaks

### DIFF
--- a/examples/vbox-layer0/README.md
+++ b/examples/vbox-layer0/README.md
@@ -1,29 +1,29 @@
-# Kraken Vagrant/Virtualbox Example
+# Layercake Vagrant/Virtualbox Example
 
 ## Table of Contents
 
-- [Kraken Vagrant/Virtualbox Example](#kraken-vagrantvirtualbox-example)
+- [Layercake Vagrant/Virtualbox Example](#layercake-vagrantvirtualbox-example)
   - [Table of Contents](#table-of-contents)
   - [Dependencies](#dependencies)
     - [WSL](#wsl)
   - [Instructions](#instructions)
-    - [Get Kraken](#get-kraken)
+    - [Get Layercake](#get-layercake)
     - [Setting up host-only networking](#setting-up-host-only-networking)
       - [MacOS network creation](#macos-network-creation)
       - [Linux network creation](#linux-network-creation)
       - [WSL network creation](#wsl-network-creation)
-  - [Release the Kraken](#release-the-kraken)
+  - [Release the Layercake](#release-the-layercake)
   - [How it works](#how-it-works)
   - [Helper scripts](#helper-scripts)
   - [How to use your own fork/branch](#how-to-use-your-own-forkbranch)
-  - [Using custom kraken-build args](#using-custom-kraken-build-args)
+  - [Using custom layercake-build args](#using-custom-layercake-build-args)
   - [How to add things to the image](#how-to-add-things-to-the-image)
     - [Adding a kernel module](#adding-a-kernel-module)
-  - [_Now: `$ go get kraken`!_](#now--go-get-kraken)
+  - [_Now: `$ go get layercake`!_](#now--go-get-layercake)
 
-The contents of this directory can be used to generate a VirtualBox virtual Kraken cluster using Vagrant and Ansible.  It has been tested on a Mac, but should work on Linux as well.
+The contents of this directory can be used to generate a VirtualBox virtual Layercake cluster using Vagrant and Ansible.  It has been tested on a Mac, but should work on Linux as well.
 
-It will build a cluster with a kraken parent and four nodes.  The nodes run a minimal [u-root](https://github.com/u-root-/u-root) image.
+It will build a cluster with a layercake parent and four nodes.  The nodes run a minimal [u-root](https://github.com/u-root-/u-root) image.
 
 ## Dependencies
 
@@ -62,20 +62,20 @@ When running in WSL mode, all commands should be run from the *Linux* side.
 
 ## Instructions
 
-### Get Kraken
+### Get Layercake
 
-You need a copy of Kraken to continue.  Choose a good working directory and run:
+You need a copy of Layercake to continue.  Choose a good working directory and run:
 
 ```bash
-$ git clone https://github.com/kraken-hpc/kraken
-Cloning into 'kraken'...
+$ git clone https://github.com/kraken-hpc/kraken-layercake
+Cloning into 'kraken-layercake'...
 remote: Enumerating objects: 43, done.
 remote: Counting objects: 100% (43/43), done.
 remote: Compressing objects: 100% (37/37), done.
 remote: Total 4694 (delta 8), reused 14 (delta 3), pack-reused 4651
 Receiving objects: 100% (4694/4694), 7.25 MiB | 13.00 MiB/s, done.
 Resolving deltas: 100% (1742/1742), done.
-$ cd kraken
+$ cd layercake
 ```
 
 ### Setting up host-only networking
@@ -138,13 +138,13 @@ $ export KRAKEN_VBOXNET="VirtualBox Host-Only Ethernet Adapter #2"
 
 You will need to set this variable any time you create a new shell.  Alternatively, you could place it in your `.bashrc`.
 
-## Release the Kraken
+## Release the Layercake
 
 Once the dependencies are installed and the host-only network is setup in VirtualBox, you can deploy a virtual cracking cluster with one command:
 
 
 ```bash
-$ bash release-the-kraken.sh
+$ bash release-the-layercake.sh
 ...
 ```
 
@@ -152,38 +152,41 @@ Note: this does *not* require root/sudo.
 
 If you are running under WSL, you will need to tell Windows to allow firewall access to vboxapi (Windows will pop up a message).
 
-This script will perform all of the necessary steps to build a virtual kraken cluster.  It will take about 3-5 minutes to complete.
+This script will perform all of the necessary steps to build a virtual layercake cluster.  It will take about 3-5 minutes to complete.
 
 ## How it works
 
-The `release-the-kraken.sh` script performs the following steps to bring up a virtual Kraken cluster.
+Note: As of `v0.1.1` the way this example works has changed.  We used to build and run layercake as a `systemd` service.  We now use `podman` to run layercake has a container that we pull from `docker.io/layercakehpc/layercake-layercake:virt-latest`.
+
+The `release-the-layercake.sh` script performs the following steps to bring up a virtual Layercake cluster.
 
 1. It verifies that we have all of the dependencies and network settings we need.
 2. It calls the script `create-nodes.sh`, which further uses the `VagrantFile` to create nodes `kr[1-4]`.  `create-nodes.sh` also immediately shuts these off as we don't want them on yet.
-3. Starts the (included) `vboxapi.go`, which provides a ReST API for VirtualBox VM power control.  This allows Kraken to control the power atate of the VMs.
-4. It calls `vagrant up kraken`, which uses the included `VagrantFile` to create and provision the "kraken" (parent) VM.  `Vagrant` calls `ansible` to handle provisioning.  `Ansible` performs a number of steps, but here are some of the more critical ones:
-   1. install necessary dependencies in the VM;
-   2. get kraken, build the `kraken-builder`;
-   3. build the kraken binaries;
-   4. setup the directory/files needed for pxeboot;
-   5. create the "layer0" image that the nodes will boot.
-   6. generate node state information
-   7. install and start kraken systemd service (and inject node state)
-6. Loads the kraken dashboard.
+3. Starts the (included) `vboxapi.go`, which provides a ReST API for VirtualBox VM power control.  This allows Layercake to control the power atate of the VMs.
+4. It calls `vagrant up layercake`, which uses the included `VagrantFile` to create and provision the "layercake" (parent) VM.  `Vagrant` calls `ansible` to handle provisioning.  `Ansible` performs a number of steps, but here are some of the more critical ones:
+5. install necessary dependencies in the VM;
+6. install `podman`;
+7. setup the tftp directory, including:
+    1. `layer0-base.gz` - the base minOS image.
+    2. `layer0-kmod.gz` - the kernel module bundle.
+    3. `layer0-conf.gz` - the minOS config set.
+8. generate a node state definition file & runtime config.
+9. `podman run` the layercake-layercake container
+10. Loads the layercake dashboard.
 
-From this point, Kraken takes over and brings the nodes up.  Once the nodes are up, it begins synchronizing state information with them.
+From this point, Layercake takes over and brings the nodes up.  Once the nodes are up, it begins synchronizing state information with them.
 
 To see more detail on any of these steps, take a look at the scripts and ansible roles included.
 
-You can find more information on what's happening in the logs.  Kraken now runs under systemd, and you can reach see the logs with `journalctl -u kraken` on the "kraken" host.  To get to the kraken host you can use either:
+You can find more information on what's happening in the logs.  Layercake now runs under systemd, and you can reach see the logs with `journalctl -u layercake` on the "layercake" host.  To get to the layercake host you can use either:
 
-`$ vagrant ssh kraken`
+`$ vagrant ssh layercake`
 
 or,
 
-`$ ssh -F ssh-config kraken`
+`$ ssh -F ssh-config layercake`
 
-If you want to login to one of the nodes, can get there from the "kraken" node.  They have an `ssh` server running on port `2022` and expect you to use a particular `ssh` key: `~vagrant/support/base/id_rsa`.  Here's an example to get to "kr1":
+If you want to login to one of the nodes, can get there from the "layercake" node.  They have an `ssh` server running on port `2022` and expect you to use a particular `ssh` key: `~vagrant/support/base/id_rsa`.  Here's an example to get to "kr1":
 
 `$ ssh -p 2022 -i ~vagrant/support/base/id_rsa kr1`
 
@@ -192,26 +195,26 @@ If you want to login to one of the nodes, can get there from the "kraken" node. 
 There are a number of helper scripts in this directory.  Here's what they do:
 
 - `create-nodes.sh` - this creates the `kr[1-4]` nodes.  It takes no arguments.  It skips any nodes that are already created.
-- `destroy-all.sh` - this destroys everything created by `release-the-kraken.sh`.  It takes no arguments.  This includes:
+- `destroy-all.sh` - this destroys everything created by `release-the-layercake.sh`.  It takes no arguments.  This includes:
    1. shutting down `vboxapi`
-   a. destroying `kraken` VM
+   a. destroying `layercake` VM
    3. destroying node VMs `kr[1-4]`
 - `destroy-nodes.sh` - this destroys nodes `kr[1-4]`.  It takes no arguments.
-- `release-the-kraken.sh` - this does a total bring-up of the example environment (as described above).  It takes no arguments.  This is (*should be*) safe to call more than once; you an call it multiple times to re-start kraken.
-- `shutdown.sh` - this shuts down a running kraken environment by: 1) shutting down `kraken` on "kraken"; 2) shutting down the `vboxapi`. You re-start kraken by re-running `release-the-kraken.sh`.
+- `release-the-layercake.sh` - this does a total bring-up of the example environment (as described above).  It takes no arguments.  This is (*should be*) safe to call more than once; you an call it multiple times to re-start layercake.
+- `shutdown.sh` - this shuts down a running layercake environment by: 1) shutting down `layercake` on "layercake"; 2) shutting down the `vboxapi`. You re-start layercake by re-running `release-the-layercake.sh`.
 
 ## How to use your own fork/branch
 
-For testing purposes, it can be nice to use your own fork & branch of kraken.  You can easily do this by changing the host vars `kr_repo` and `kr_repo_version` in `kraken.yml`.  `kr_repo` should be the full URL for the repo (e.g. https://github.com/kraken-hpc/kraken.git).  `kr_repo_version` can be any branch or tag name.  `kr_repo_version` must be provided, even if it is "main".
+For testing purposes, it can be nice to use your own fork & branch of layercake.  You can easily do this by changing the host vars `kr_repo` and `kr_repo_version` in `layercake.yml`.  `kr_repo` should be the full URL for the repo (e.g. https://github.com/layercake-hpc/layercake.git).  `kr_repo_version` can be any branch or tag name.  `kr_repo_version` must be provided, even if it is "main".
 
-## Using custom kraken-build args
+## Using custom layercake-build args
 
-You can add custom arguments to `kraken-build` by setting `kr_build_args` in `kraken.yml`.  You should avoid changing `-dir` and `-config`, as the ansible role expects to set these.
+You can add custom arguments to `layercake-build` by setting `kr_build_args` in `layercake.yml`.  You should avoid changing `-dir` and `-config`, as the ansible role expects to set these.
 
 The following args may be particularly helpful:
 
-- `-pprof` - build kraken with pprof support
-- `-race` - build kraken with the race detection
+- `-pprof` - build layercake with pprof support
+- `-race` - build layercake with the race detection
 
 ## How to add things to the image
 
@@ -221,7 +224,7 @@ Making the image large will likely lead to unexpected problems.
 
 ### Adding a kernel module
 
-The [uinit](https://github.com/kraken-hpc/uinit) process that initializes nodes runs a utility called [modscan](https://github.com/bensallen/modscan) that will automatically add any modules needed for detected hardware.
+The [uinit](https://github.com/layercake-hpc/uinit) process that initializes nodes runs a utility called [modscan](https://github.com/bensallen/modscan) that will automatically add any modules needed for detected hardware.
 
 In the case that you need to add a non-hardware module, e.g. a filesystem driver:
 
@@ -235,4 +238,4 @@ In the case that you need to add a non-hardware module, e.g. a filesystem driver
        cmd: /bbin/modprobe mymodule
    ```
 
-## _Now: `$ go get kraken`!_
+## _Now: `$ go get layercake`!_

--- a/examples/vbox-layer0/release-the-kraken.sh
+++ b/examples/vbox-layer0/release-the-kraken.sh
@@ -116,8 +116,8 @@ bash create-nodes.sh 2>&1 | tee -a log/create-nodes.log
 echo "(RE)Starting vboxapi, log file in log/vboxapi.log"
 echo RUN: pkill vboxapi
 pkill vboxapi || true
-echo RUN: nohup go run "${VBOXAPI}" -v -ip "${VBOXNET_IP}"
-nohup go run "${VBOXAPI}" -v -ip "${VBOXNET_IP}" -vbm "${VB}" > log/vboxapi.log &
+echo RUN: nohup go run "${VBOXAPI}" -v -ip 0.0.0.0
+nohup go run "${VBOXAPI}" -v -ip 0.0.0.0 -vbm "${VB}" > log/vboxapi.log &
 
 echo "Creating and provisioning the kraken parent (this may take a while)..."
 if "$VB" list vms | grep -q kraken; then


### PR DESCRIPTION
Resolves #35
We do two things:

1. Make `vboxapi` listen on 0.0.0.0 so the `vbox` interface doesn't have to be up.
2. Update thew example README to reflect the new way of running with containers.
